### PR TITLE
fix(release): fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - run: npm ci
+      - run: npm install
       - run: npm run build --if-present
       - run: npm test
       - run: npx semantic-release


### PR DESCRIPTION
Removes `npm run ci` from release workflow

closes #5